### PR TITLE
[DNM] stress test JSON parsing with Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,5 +49,15 @@ let package:Package = .init(
             dependencies: [
                 .target(name: "JSON"),
             ]),
+
+        .testTarget(name: "JSONStressTestST",
+            dependencies: [
+                .target(name: "JSON"),
+            ]),
+
+        .executableTarget(name: "JSONStressTest",
+            dependencies: [
+                .target(name: "JSON"),
+            ]),
     ]
 )

--- a/Sources/JSONStressTest/main.swift
+++ b/Sources/JSONStressTest/main.swift
@@ -1,0 +1,17 @@
+import FoundationEssentials
+import JSON
+
+@main
+enum Main
+{
+    static func main() throws
+    {
+        let file:Data = try Data.init(
+            contentsOf: URL.init(fileURLWithPath: "Test Inputs/Swift.symbols.json"))
+
+        let json:JSON = JSON.init(utf8: [UInt8].init(file)[...])
+        let object:JSON.Object = try .init(parsing: json)
+
+        print(object.fields.map(\.0))
+    }
+}

--- a/Sources/JSONStressTestST/main.swift
+++ b/Sources/JSONStressTestST/main.swift
@@ -1,0 +1,19 @@
+import Foundation
+import JSON
+import Testing
+
+@Suite
+enum Main
+{
+    @Test
+    static func main() throws
+    {
+        let file:Data = try Data.init(
+            contentsOf: URL.init(fileURLWithPath: "Test Inputs/Swift.symbols.json"))
+
+        let json:JSON = JSON.init(utf8: [UInt8].init(file)[...])
+        let object:JSON.Object = try .init(parsing: json)
+
+        print(object.fields.map(\.0))
+    }
+}


### PR DESCRIPTION
this branch repro’s an issue possibly in swift-testing where JSON parsing takes much, much longer under `swift test -c release` than `swift run -c release`