### PR TITLE
Lower minimum required Swift version from 5.10 to 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:5.9
 import PackageDescription
 
 let package:Package = .init(

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A pure Swift JSON parsing and encoding library designed for high-performance, hi
 
 ## Requirements
 
-The swift-json library requires Swift 5.10 or later.
+The swift-json library requires Swift 5.9 or later.
 
 
 | Platform | Status |


### PR DESCRIPTION
Lower minimum required Swift version from 5.10 to 5.9.

Resolve #87