### PR TITLE
Adds initializers to support parsing JSON directly from a Span.

### DIFF
--- a/Sources/JSONParsing/JSON.Array (ext).swift
+++ b/Sources/JSONParsing/JSON.Array (ext).swift
@@ -6,14 +6,6 @@ extension JSON.Array {
     public init(parsing json: JSON) throws {
         self.init(try JSON.NodeRule<Int>.Array.parse(json.utf8))
     }
-    /// Attempts to parse a JSON array from a span
-    public init(parsing span: Span<UInt8>) throws {
-        self.init(
-            try span.withUnsafeBufferPointer { buffer in
-                try JSON.NodeRule<Int>.Array.parse(buffer)
-            }
-        )
-    }
     /// Attempts to parse a JSON array from a raw span
     public init(parsing span: RawSpan) throws {
         self.init(

--- a/Sources/JSONParsing/JSON.Node (ext).swift
+++ b/Sources/JSONParsing/JSON.Node (ext).swift
@@ -8,13 +8,6 @@ extension JSON.Node {
         self = try JSON.RootRule<Int>.parse(json.utf8)
     }
     /// Attempts to parse a complete JSON message (either an ``Array`` or an
-    /// ``Object``) from a span.
-    public init(parsing span: Span<UInt8>) throws {
-        self = try span.withUnsafeBufferPointer { buffer in
-            try JSON.RootRule<Int>.parse(buffer)
-        }
-    }
-    /// Attempts to parse a complete JSON message (either an ``Array`` or an
     /// ``Object``) from a raw span.
     public init(parsing span: RawSpan) throws {
         self = try span.withUnsafeBytes { buffer in

--- a/Sources/JSONParsing/JSON.Object (ext).swift
+++ b/Sources/JSONParsing/JSON.Object (ext).swift
@@ -9,14 +9,6 @@ extension JSON.Object {
     public init(parsing json: JSON) throws {
         self.init(try JSON.NodeRule<Int>.Object.parse(json.utf8))
     }
-    /// Attempts to parse a JSON object from a span.
-    public init(parsing span: Span<UInt8>) throws {
-        self.init(
-            try span.withUnsafeBufferPointer { buffer in
-                try JSON.NodeRule<Int>.Object.parse(buffer)
-            }
-        )
-    }
     /// Attempts to parse a JSON object from a raw span.
     public init(parsing span: RawSpan) throws {
         self.init(


### PR DESCRIPTION
Hi @tayloraswift, I found those additions to be quite useful, to avoid unnecessary copies of the JSON buffer to be parsed. Would you want to take them? Currently they need to use the unsafe APIs because the parser requires `Collection` which span does not provide.