### PR TITLE
[minor]: Relax minimum platform version requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package: Package = .init(
     name: "swift-json",
-    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18), .watchOS(.v11), .visionOS(.v2)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
     products: [
         .library(name: "JavaScriptPersistence", targets: ["JavaScriptPersistence"]),
         .library(name: "JQ", targets: ["JQ"]),

--- a/Sources/JSONAST/JSON.Number.Inline.swift
+++ b/Sources/JSONAST/JSON.Number.Inline.swift
@@ -76,8 +76,8 @@ extension JSON.Number.Inline {
                 return T.init(exactly: negated)
             }
 
-            // slow path, underflow occured
-            if  T.bitWidth > 64 {
+            // slow path, underflow occurred
+            if  T.bitWidth > 64, #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
                 return T.init(exactly: -Int128.init(self.units))
             } else {
                 return nil
@@ -102,6 +102,7 @@ extension JSON.Number.Inline {
                 return (units: units, places: places)
             }
             if  T.bitWidth > 64,
+               #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *),
                 let units: T = .init(exactly: -Int128.init(self.units)) {
                 return (units: units, places: places)
             } else {

--- a/Sources/JSONDecoding/Conformances/Int128 (ext).swift
+++ b/Sources/JSONDecoding/Conformances/Int128 (ext).swift
@@ -1,1 +1,2 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int128: JSONDecodable {}

--- a/Sources/JSONDecoding/Conformances/UInt128 (ext).swift
+++ b/Sources/JSONDecoding/Conformances/UInt128 (ext).swift
@@ -1,1 +1,2 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt128: JSONDecodable {}

--- a/Sources/JSONEncoding/Conformances/Int128 (ext).swift
+++ b/Sources/JSONEncoding/Conformances/Int128 (ext).swift
@@ -1,1 +1,2 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int128: JSONEncodable {}

--- a/Sources/JSONEncoding/Conformances/UInt128 (ext).swift
+++ b/Sources/JSONEncoding/Conformances/UInt128 (ext).swift
@@ -1,1 +1,2 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt128: JSONEncodable {}

--- a/Sources/JSONTests/IntegerOverflow.swift
+++ b/Sources/JSONTests/IntegerOverflow.swift
@@ -24,6 +24,7 @@ import Testing
         try Self.decode(Int64.min, to: Int64.self)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test static func AsInt128Inline() throws {
         let field: JSON.FieldDecoder<Never?> = .init(
             key: nil,
@@ -32,9 +33,11 @@ import Testing
 
         #expect(try field.decode() == -Int128.init(UInt64.max))
     }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test static func AsInt128Min() throws {
         try Self.decode(Int128.min, to: Int128.self)
     }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test static func AsInt128Max() throws {
         try Self.decode(Int128.max, to: Int128.self)
     }
@@ -62,9 +65,11 @@ import Testing
         try Self.decode(UInt64.max, to: UInt64.self)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test static func AsUInt128() throws {
         try Self.decode(256, to: UInt128.self)
     }
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test static func AsUInt128Max() throws {
         try Self.decode(UInt128.max, to: UInt128.self)
     }

--- a/Sources/JSONTests/ParsingNumerics.swift
+++ b/Sources/JSONTests/ParsingNumerics.swift
@@ -69,6 +69,7 @@ import Testing
         #expect(encoded.value.bitPattern == decoded.value.bitPattern)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test(
         arguments: [
             Int128.min,
@@ -84,6 +85,7 @@ import Testing
         #expect(encoded.value == decoded.value)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @Test(
         arguments: [
             0,

--- a/Sources/JavaScriptPersistence/Array (ext).swift
+++ b/Sources/JavaScriptPersistence/Array (ext).swift
@@ -1,8 +1,10 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Array: ConvertibleToJSValue where Element: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         .object(.array(self.map(\.jsValue)))
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Array: ConstructibleFromJSValue where Element: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> [Element]? {
         guard case .object(let object) = value.storage, object.isArray else {

--- a/Sources/JavaScriptPersistence/BinaryFloatingPoint (ext).swift
+++ b/Sources/JavaScriptPersistence/BinaryFloatingPoint (ext).swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension BinaryFloatingPoint where Self: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> Self? {
         switch value.storage {

--- a/Sources/JavaScriptPersistence/Bool (ext).swift
+++ b/Sources/JavaScriptPersistence/Bool (ext).swift
@@ -1,6 +1,8 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Bool: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .boolean(self) }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Bool: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> Bool? { value.boolean }
 }

--- a/Sources/JavaScriptPersistence/ConstructibleFromJSValue.swift
+++ b/Sources/JavaScriptPersistence/ConstructibleFromJSValue.swift
@@ -1,6 +1,8 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public protocol ConstructibleFromJSValue {
     static func construct(from value: JSValue) -> Self?
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension ConstructibleFromJSValue where Self: SignedInteger {
     @inlinable public static func construct(from value: JSValue) -> Self? {
         switch value.storage {
@@ -10,6 +12,7 @@ extension ConstructibleFromJSValue where Self: SignedInteger {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension ConstructibleFromJSValue where Self: UnsignedInteger {
     @inlinable public static func construct(from value: JSValue) -> Self? {
         switch value.storage {

--- a/Sources/JavaScriptPersistence/ConvertibleToJSValue.swift
+++ b/Sources/JavaScriptPersistence/ConvertibleToJSValue.swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public protocol ConvertibleToJSValue {
     var jsValue: JSValue { get }
 }

--- a/Sources/JavaScriptPersistence/Double (ext).swift
+++ b/Sources/JavaScriptPersistence/Double (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Double: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Double: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(self) }
 }

--- a/Sources/JavaScriptPersistence/Float (ext).swift
+++ b/Sources/JavaScriptPersistence/Float (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Float: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Float: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/Int (ext).swift
+++ b/Sources/JavaScriptPersistence/Int (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         if  let double: Double = .init(exactly: self) {

--- a/Sources/JavaScriptPersistence/Int16 (ext).swift
+++ b/Sources/JavaScriptPersistence/Int16 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int16: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int16: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/Int32 (ext).swift
+++ b/Sources/JavaScriptPersistence/Int32 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int32: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int32: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/Int64 (ext).swift
+++ b/Sources/JavaScriptPersistence/Int64 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int64: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int64: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         .bigInt(JSBigInt.init(int128: Int128.init(self)))

--- a/Sources/JavaScriptPersistence/Int8 (ext).swift
+++ b/Sources/JavaScriptPersistence/Int8 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int8: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Int8: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/JSBigInt.swift
+++ b/Sources/JavaScriptPersistence/JSBigInt.swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public final class JSBigInt {
     @usableFromInline let int128: Int128
 
@@ -5,6 +6,7 @@ public final class JSBigInt {
         self.int128 = int128
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSBigInt: Equatable {
     @inlinable public static func == (a: JSBigInt, b: JSBigInt) -> Bool {
         a.int128 == b.int128

--- a/Sources/JavaScriptPersistence/JSObject.swift
+++ b/Sources/JavaScriptPersistence/JSObject.swift
@@ -1,5 +1,6 @@
 public import JSON
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public final class JSObject {
     @usableFromInline var object: [String: JSValue]
     @usableFromInline var buffer: [JSValue]
@@ -11,6 +12,7 @@ public final class JSObject {
         self.isArray = isArray
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject {
     @inlinable convenience public init(object: [String: JSValue]) {
         self.init(object: object, buffer: [], isArray: false)
@@ -19,6 +21,7 @@ extension JSObject {
         self.init(object: [:], buffer: buffer, isArray: true)
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject {
     private convenience init(json: borrowing JSON.Object) throws {
         var object: [String: JSValue] = .init(minimumCapacity: json.fields.count)
@@ -34,6 +37,7 @@ extension JSObject {
         self.init(buffer: try json.elements.map(JSValue.init(json:)))
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject {
     @inlinable public static func object(_ properties: [String: JSValue] = [:]) -> JSObject {
         .init(object: properties)
@@ -45,18 +49,22 @@ extension JSObject {
     public static func json(_ json: JSON.Object) throws -> JSObject { try .init(json: json) }
     public static func json(_ json: JSON.Array) throws -> JSObject { try .init(json: json) }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .object(self) }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> JSObject? { value.object }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject {
     @inlinable public var properties: [String: JSValue] { self.object }
     @inlinable public func push(_ value: JSValue) {
         self.buffer.append(value)
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject {
     @inlinable public subscript(index: Int) -> JSValue {
         get {
@@ -103,6 +111,7 @@ extension JSObject {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject: JSONEncodable {
     public func encode(to json: inout JSON) {
         if  self.isArray {
@@ -118,6 +127,7 @@ extension JSObject: JSONEncodable {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSObject: JSONDecodable {
     public convenience init(json: borrowing JSON.Node) throws {
         switch json {

--- a/Sources/JavaScriptPersistence/JSString.swift
+++ b/Sources/JavaScriptPersistence/JSString.swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 @frozen public struct JSString: Equatable {
     @usableFromInline let string: String
 
@@ -5,17 +6,21 @@
         self.string = string
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSString: ExpressibleByStringLiteral {
     @inlinable public init(stringLiteral: String) {
         self.init(stringLiteral)
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSString: CustomStringConvertible, LosslessStringConvertible {
     @inlinable public var description: String { self.string }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSString: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .string(self) }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSString: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> JSString? {
         guard case .string(let string) = value.storage else {

--- a/Sources/JavaScriptPersistence/JSSymbol.swift
+++ b/Sources/JavaScriptPersistence/JSSymbol.swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public final class JSSymbol {
     public let name: String?
 

--- a/Sources/JavaScriptPersistence/JSValue.Storage.swift
+++ b/Sources/JavaScriptPersistence/JSValue.Storage.swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     @frozen @usableFromInline enum Storage {
         case boolean(Bool)

--- a/Sources/JavaScriptPersistence/JSValue.swift
+++ b/Sources/JavaScriptPersistence/JSValue.swift
@@ -1,11 +1,13 @@
 public import JSON
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 @frozen public struct JSValue {
     @usableFromInline let storage: Storage
     @inlinable init(storage: Storage) {
         self.storage = storage
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     @inlinable public static func boolean(_ value: Bool) -> Self {
         .init(storage: .boolean(value))
@@ -32,6 +34,7 @@ extension JSValue {
         .init(storage: .bigInt(value))
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue: JSONEncodable {
     public func encode(to json: inout JSON) {
         switch self.storage {
@@ -67,6 +70,7 @@ extension JSValue: JSONEncodable {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue: JSONDecodable {
     public init(json: borrowing JSON.Node) throws {
         switch json {
@@ -106,6 +110,7 @@ extension JSValue: JSONDecodable {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     private static func number(_ int128: Int128) -> JSValue {
         if  let double: Double = .init(exactly: int128) {
@@ -123,12 +128,15 @@ extension JSValue {
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> Self? { value }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { self }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     @inlinable public var number: Double? {
         guard case .number(let value) = self.storage else {
@@ -144,6 +152,7 @@ extension JSValue {
         return value
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     @inlinable public var jsString: JSString? {
         guard case .string(let value) = self.storage else {
@@ -152,6 +161,7 @@ extension JSValue {
         return value
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension JSValue {
     @inlinable public var boolean: Bool? {
         guard case .boolean(let value) = self.storage else {

--- a/Sources/JavaScriptPersistence/Optional (ext).swift
+++ b/Sources/JavaScriptPersistence/Optional (ext).swift
@@ -1,3 +1,4 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Optional: ConstructibleFromJSValue where Wrapped: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> Self? {
         switch value.storage {
@@ -11,6 +12,7 @@ extension Optional: ConstructibleFromJSValue where Wrapped: ConstructibleFromJSV
         }
     }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension Optional: ConvertibleToJSValue where Wrapped: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         self?.jsValue ?? .null

--- a/Sources/JavaScriptPersistence/String (ext).swift
+++ b/Sources/JavaScriptPersistence/String (ext).swift
@@ -1,6 +1,8 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension String: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .string(JSString.init(self)) }
 }
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension String: ConstructibleFromJSValue {
     @inlinable public static func construct(from value: JSValue) -> String? { value.string }
 }

--- a/Sources/JavaScriptPersistence/UInt (ext).swift
+++ b/Sources/JavaScriptPersistence/UInt (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         if  let double: Double = .init(exactly: self) {

--- a/Sources/JavaScriptPersistence/UInt16 (ext).swift
+++ b/Sources/JavaScriptPersistence/UInt16 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt16: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt16: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/UInt32 (ext).swift
+++ b/Sources/JavaScriptPersistence/UInt32 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt32: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt32: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }

--- a/Sources/JavaScriptPersistence/UInt64 (ext).swift
+++ b/Sources/JavaScriptPersistence/UInt64 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt64: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt64: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue {
         .bigInt(JSBigInt.init(int128: Int128.init(self)))

--- a/Sources/JavaScriptPersistence/UInt8 (ext).swift
+++ b/Sources/JavaScriptPersistence/UInt8 (ext).swift
@@ -1,4 +1,6 @@
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt8: ConstructibleFromJSValue {}
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 extension UInt8: ConvertibleToJSValue {
     @inlinable public var jsValue: JSValue { .number(Double.init(self)) }
 }


### PR DESCRIPTION
Unfinished draft to relax minimum platform version requirements to their pre-2.1.0 versions.

Restricts `Int128` & `UInt128` code to platforms that support them, which was simple for all products except JavaScriptPersistence.

To show that all other code can build with the lower platform restrictions, this temporarily excludes the JavaScriptPersistence library product from the package.

For the real solution, JavaScriptPersistence can be supported by either:

1. Having non-128-bit fallbacks & being reinstated in the package.
2. Guarding all its 128-bit code with platform version checks.
3. Being moved into a separate package in the swift-json repo.
4. Being moved into a separate package in a separate repo.
5. Having a build setting that includes/excludes it in the package, & that sets the minimum platform versions to as old as possible.
6. Being resolved in some other manner.

I would normally say this should be a major version bump, but maybe you bump versions differently than semantic versioning, as 2.1.0 should have been a major semantic version bump since it changed the minimum platform requirements (and possibly other versions should have been, too).

I'll put whatever you want in the PR title, or you can edit it yourself.

Resolve #105