### PR TITLE
[minor]: escape ASCII control characters when printing JSON strings, add tests

### DIFF
--- a/Sources/JSONAST/JSON.Literal.swift
+++ b/Sources/JSONAST/JSON.Literal.swift
@@ -23,8 +23,8 @@ extension JSON.Literal where Value: StringProtocol {
                 json.utf8.append(0x75) // 'u'
                 json.utf8.append(0x30) // '0'
                 json.utf8.append(0x30) // '0'
-                json.utf8.append(0x30 + codeunit >> 4)
-                json.utf8.append(0x30 + codeunit & 15)
+                json.utf8.append(JSON.hex(codeunit >> 4))
+                json.utf8.append(JSON.hex(codeunit & 15))
             } else {
                 json.utf8.append(codeunit)
             }

--- a/Sources/JSONAST/JSON.Literal.swift
+++ b/Sources/JSONAST/JSON.Literal.swift
@@ -18,6 +18,13 @@ extension JSON.Literal where Value: StringProtocol {
         for codeunit: UInt8 in self.value.utf8 {
             if  let code: JSON.EscapeCode = .init(escaping: codeunit) {
                 json.utf8 += code
+            } else if codeunit < 0x20 {
+                json.utf8.append(0x5C) // '\'
+                json.utf8.append(0x75) // 'u'
+                json.utf8.append(0x30) // '0'
+                json.utf8.append(0x30) // '0'
+                json.utf8.append(0x30 + codeunit >> 4)
+                json.utf8.append(0x30 + codeunit & 15)
             } else {
                 json.utf8.append(codeunit)
             }

--- a/Sources/JSONAST/JSON.swift
+++ b/Sources/JSONAST/JSON.swift
@@ -11,3 +11,8 @@ extension JSON: CustomStringConvertible {
         .init(decoding: self.utf8, as: UTF8.self)
     }
 }
+extension JSON {
+    @inline(always) @inlinable static func hex(_ remainder: UInt8) -> UInt8 {
+        remainder < 10 ? remainder + 0x30 : remainder + 0x37
+    }
+}

--- a/Sources/JSONTests/Rendering.swift
+++ b/Sources/JSONTests/Rendering.swift
@@ -8,9 +8,15 @@ import Testing
         #expect("\(expected)" == "\(try JSON.Node.init(parsingFragment: "\(expected)"))")
     }
 
-    @Test static func StringControlCharacters() throws {
+    @Test static func StringControlCharactersDLE() throws {
         let expected: JSON.Node = "\u{10}"
         #expect("\(expected)" == "\"\\u0010\"")
+        #expect("\(expected)" == "\(try JSON.Node.init(parsingFragment: "\(expected)"))")
+    }
+
+    @Test static func StringControlCharactersVT() throws {
+        let expected: JSON.Node = "\u{0B}"
+        #expect("\(expected)" == "\"\\u000B\"")
         #expect("\(expected)" == "\(try JSON.Node.init(parsingFragment: "\(expected)"))")
     }
 }

--- a/Sources/JSONTests/Rendering.swift
+++ b/Sources/JSONTests/Rendering.swift
@@ -1,0 +1,16 @@
+import JSON
+import Testing
+
+@Suite enum Rendering {
+    @Test static func StringNewline() throws {
+        let expected: JSON.Node = "\n"
+        #expect("\(expected)" == "\"\\n\"")
+        #expect("\(expected)" == "\(try JSON.Node.init(parsingFragment: "\(expected)"))")
+    }
+
+    @Test static func StringControlCharacters() throws {
+        let expected: JSON.Node = "\u{10}"
+        #expect("\(expected)" == "\"\\u0010\"")
+        #expect("\(expected)" == "\(try JSON.Node.init(parsingFragment: "\(expected)"))")
+    }
+}


### PR DESCRIPTION
fixes #130 